### PR TITLE
Add React Vite frontend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+build
+.dist
+.DS_Store
+frontend/node_modules
+frontend/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# familyapp
+# Family App
+
+This repository contains the frontend scaffolded with **React**, **Vite**, and **Tailwind CSS**.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open your browser at the address printed in the terminal.
+
+The app features a responsive navigation bar with pages for **Home**, **Meals**, **Tasks**, and **Finance**. Each page currently contains placeholder content that can be extended.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Family App</title>
+  </head>
+  <body class="bg-gray-50 dark:bg-gray-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "familyapp-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.4",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import Home from './pages/Home';
+import Meals from './pages/Meals';
+import Tasks from './pages/Tasks';
+import Finance from './pages/Finance';
+
+function App() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-grow container mx-auto p-4">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/meals" element={<Meals />} />
+          <Route path="/tasks" element={<Tasks />} />
+          <Route path="/finance" element={<Finance />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+const linkClass =
+  'px-3 py-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700';
+
+function Navbar() {
+  return (
+    <nav className="bg-white dark:bg-gray-800 shadow mb-4">
+      <div className="container mx-auto p-4 flex justify-between items-center">
+        <h1 className="text-xl font-bold">Family App</h1>
+        <div className="space-x-2">
+          <NavLink end to="/" className={({ isActive }) => `${linkClass} ${isActive ? 'font-semibold' : ''}`}>Home</NavLink>
+          <NavLink to="/meals" className={({ isActive }) => `${linkClass} ${isActive ? 'font-semibold' : ''}`}>Meals</NavLink>
+          <NavLink to="/tasks" className={({ isActive }) => `${linkClass} ${isActive ? 'font-semibold' : ''}`}>Tasks</NavLink>
+          <NavLink to="/finance" className={({ isActive }) => `${linkClass} ${isActive ? 'font-semibold' : ''}`}>Finance</NavLink>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+export default Navbar;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Finance.jsx
+++ b/frontend/src/pages/Finance.jsx
@@ -1,0 +1,10 @@
+function Finance() {
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-4">Finance</h2>
+      <p>Overview of family finances.</p>
+    </section>
+  );
+}
+
+export default Finance;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,10 @@
+function Home() {
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-4">Home</h2>
+      <p>Welcome to the family app!</p>
+    </section>
+  );
+}
+
+export default Home;

--- a/frontend/src/pages/Meals.jsx
+++ b/frontend/src/pages/Meals.jsx
@@ -1,0 +1,10 @@
+function Meals() {
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-4">Meals</h2>
+      <p>Plan and track meals here.</p>
+    </section>
+  );
+}
+
+export default Meals;

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -1,0 +1,10 @@
+function Tasks() {
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-4">Tasks</h2>
+      <p>Manage your tasks and chores.</p>
+    </section>
+  );
+}
+
+export default Tasks;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- add React+Vite project under `frontend` with Tailwind CSS
- create navigation bar and pages for Home, Meals, Tasks and Finance
- configure React Router and Tailwind
- update README with setup instructions

## Testing
- `npm install` *(fails: no network access)*